### PR TITLE
Discord bot token exposed

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,7 @@ import discord
 import asyncio
 from discord.ext import commands
 from discord.utils import get
-TOKEN = 'Nzg5NTMwNzkwMjc5MTE4OTM4.X9zZ2Q.o9GWqAHKcgI6Zfmo92EbSJ8P_RU'
+TOKEN = 'INSERT_TOKEN_HERE'
 BOT_PREFIX = '.'
 
 client = commands.AutoShardedBot(command_prefix=BOT_PREFIX)


### PR DESCRIPTION
In the bot file, the token used for authenticating with Discord was not redacted when pushing to GitHub. This can be remedied by merging this PR, as well as following appropriate steps to:
- reset the bot token via Discord's developer dashboard; and:
- [purging the token from the repo](https://docs.github.com/en/github/authenticating-to-github/removing-sensitive-data-from-a-repository)